### PR TITLE
Ep14 updates

### DIFF
--- a/Episode-14/after/RMQAdvanced/Gemfile.lock
+++ b/Episode-14/after/RMQAdvanced/Gemfile.lock
@@ -1,7 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    rake (10.1.1)
+    rake (12.3.1)
     ruby_motion_query (0.5.5)
 
 PLATFORMS
@@ -10,3 +10,6 @@ PLATFORMS
 DEPENDENCIES
   rake
   ruby_motion_query
+
+BUNDLED WITH
+   1.16.3

--- a/Episode-14/after/RMQAdvanced/Rakefile
+++ b/Episode-14/after/RMQAdvanced/Rakefile
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 $:.unshift("/Library/RubyMotion/lib")
+$:.unshift("~/.rubymotion/rubymotion-templates")
+
 require 'motion/project/template/ios'
 
 begin
@@ -11,4 +13,5 @@ end
 Motion::Project::App.setup do |app|
   # Use `rake config' to see complete project settings.
   app.name = 'RMQAdvanced'
+  app.info_plist['NSPhotoLibraryAddUsageDescription'] = 'This app adds screen captures to the Photo Library'
 end

--- a/Episode-14/before/RMQAdvanced/Gemfile.lock
+++ b/Episode-14/before/RMQAdvanced/Gemfile.lock
@@ -1,7 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    rake (10.1.1)
+    rake (12.3.1)
     ruby_motion_query (0.5.5)
 
 PLATFORMS
@@ -10,3 +10,6 @@ PLATFORMS
 DEPENDENCIES
   rake
   ruby_motion_query
+
+BUNDLED WITH
+   1.14.6

--- a/Episode-14/before/RMQAdvanced/Rakefile
+++ b/Episode-14/before/RMQAdvanced/Rakefile
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 $:.unshift("/Library/RubyMotion/lib")
+$:.unshift("~/.rubymotion/rubymotion-templates") 
+
 require 'motion/project/template/ios'
 
 begin


### PR DESCRIPTION
Fixes the before & after project's rake gem version and adds the rubymotion templates to the Rakefile

Also fixes the crash, where `NSPhotoLibraryAddUsageDescription` is now required (iOS 11 change) if you are saving things to the camera roll.